### PR TITLE
⚠ Revert default behaviour

### DIFF
--- a/examples/00deep/main.py
+++ b/examples/00deep/main.py
@@ -1,6 +1,8 @@
 from magicalimport import import_from_physical_path
 
-foo = import_from_physical_path("../a/b/c/foo.py")
+foo = import_from_physical_path("a/b/c/foo.py")
 print(foo.name)
 foo = import_from_physical_path("../a/b/c/foo.py", here=__file__)
+print(foo.name)
+foo = import_from_physical_path("../a/b/c/foo.py", cwd=False)
 print(foo.name)

--- a/examples/00deep/output.txt
+++ b/examples/00deep/output.txt
@@ -1,2 +1,3 @@
 foo
 foo
+foo

--- a/examples/01as/main.py
+++ b/examples/01as/main.py
@@ -1,6 +1,6 @@
 from magicalimport import import_from_physical_path
 
-foo = import_from_physical_path("../a/b/c/foo.py", as_="foo2")
+foo = import_from_physical_path("../a/b/c/foo.py", as_="foo2", here=__file__)
 print(foo.name)
 
 import foo2  # noqa: F401

--- a/magicalimport/__init__.py
+++ b/magicalimport/__init__.py
@@ -45,6 +45,10 @@ def import_from_physical_path(path, as_=None, here=None, _depth=1, cwd=True):
         elif _depth > 0:
             frame = sys._getframe(_depth)  # xxx: black magic
             here = frame.f_globals["__file__"]
+        else:
+            raise ValueError(
+                "invalid option found _depth={}, cwd={}".format(_depth, cwd)
+            )
     if here is not None:
         here = here if os.path.isdir(here) else os.path.dirname(here)
         here = os.path.abspath(here)

--- a/magicalimport/__init__.py
+++ b/magicalimport/__init__.py
@@ -36,7 +36,7 @@ def _module_id_from_path(path):
 _FAILED = set()  # singleton
 
 
-def import_from_physical_path(path, as_=None, here=None, _depth=1, cwd=False):
+def import_from_physical_path(path, as_=None, here=None, _depth=1, cwd=True):
     global _FAILED
 
     if here is None:


### PR DESCRIPTION
REVERT #15 's change

## :warning:  rational

this library has two use-cases

1. as library
2. as daily programming

As library, default should be `cwd=True`. Because, usually, the argument passed from Command Line.

#15 's change, for daily programming, but Low priority