### PR TITLE
Drop support for Python < 3.10

### DIFF
--- a/magicalimport/compat.py
+++ b/magicalimport/compat.py
@@ -8,78 +8,17 @@ __ALL__ = [
 ]
 
 
-try:
-    from importlib import import_module  # NOQA
-    from importlib.util import spec_from_file_location
-    from importlib.util import module_from_spec
+from importlib import import_module  # NOQA
+from importlib.util import spec_from_file_location
+from importlib.util import module_from_spec
 
-    def _create_module(module_id, path):
-        spec = spec_from_file_location(module_id, path)
-        module = module_from_spec(spec)
-        sys.modules[module_id] = module
-        spec.loader.exec_module(module)
-        return module
-
-
-except ImportError:
-    try:
-        # for 3.3, 3.4
-        from importlib import machinery
-
-        def _create_module(module_id, path):
-            return machinery.SourceFileLoader(module_id, path).load_module()
-
-    except ImportError:
-        # patching for import machinery
-        # https://bitbucket.org/ericsnowcurrently/importlib2/issues/8/unable-to-import-importlib2machinery
-        import importlib2._fixers as f
-
-        fix_importlib_original = f.fix_importlib
-
-        def fix_importlib(ns):
-            if ns["__name__"] == "importlib2.machinery":
-
-                class _LoaderBasics:
-                    load_module = object()
-
-                ns["_LoaderBasics"] = _LoaderBasics
-
-                class FileLoader:
-                    load_module = object()
-
-                ns["FileLoader"] = FileLoader
-
-                class _NamespaceLoader:
-                    load_module = object()
-                    module_repr = object()
-
-                ns["_NamespaceLoader"] = _NamespaceLoader
-            fix_importlib_original(ns)
-
-        f.fix_importlib = fix_importlib
-        from importlib2 import machinery
-        from importlib2 import import_module  # NOQA
-
-        def _create_module(module_id, path):
-            return machinery.SourceFileLoader(module_id, path).load_module()
+def _create_module(module_id, path):
+    spec = spec_from_file_location(module_id, path)
+    module = module_from_spec(spec)
+    sys.modules[module_id] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-try:
-    ModuleNotFoundError = ModuleNotFoundError
-except NameError:
-    try:
-        from importlib2 import ModuleNotFoundError
-
-        ModuleNotFoundError = ModuleNotFoundError
-    except ImportError:
-        # for <3.6
-        class ModuleNotFoundError(ImportError):
-            fake = True
-
-
-try:
-    FileNotFoundError = FileNotFoundError
-except NameError:
-
-    class FileNotFoundError(OSError):
-        fake = True
+# ModuleNotFoundError is built-in in Python 3.6+
+# FileNotFoundError is built-in in Python 3.3+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "magicalimport"
 dynamic = ["version"]
 description = "importing a module by physical file path"
 readme = "README.rst"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*" # Assuming support for 2.7 and 3.5+
+requires-python = ">=3.10"
 license = { text = "MIT License" } # Assuming MIT based on common practice, will verify if LICENSE file exists
 authors = [
     { name = "podhmo", email = "ababjam61+github@gmail.com" }
@@ -20,21 +20,12 @@ keywords = ["import", "physical address", "file path"]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
 
-dependencies = [
-    'importlib2; python_version < "3"',
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/podhmo/magicalimport"
@@ -53,4 +44,3 @@ packages = { find = { exclude = ["magicalimport.tests*"] } }
 version = {file = "VERSION"}
 
 [tool.bdist_wheel]
-universal = true


### PR DESCRIPTION
This commit updates the project to support Python 3.10 and newer versions.

Key changes:
- Modified `pyproject.toml` to set `requires-python = ">=3.10"`, removed classifiers for older Python versions, and eliminated the `importlib2` dependency and `universal=true` wheel setting.
- Simplified `magicalimport/compat.py` by removing compatibility layers for features now standard in Python 3.10+, including direct imports from `importlib` and reliance on built-in `ModuleNotFoundError` and `FileNotFoundError` exceptions.